### PR TITLE
chore: update scout-for-lol version to 1.0.6

### DIFF
--- a/cdk8s/src/versions/versions.ts
+++ b/cdk8s/src/versions/versions.ts
@@ -100,7 +100,7 @@ const versions = {
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver
   "koush/scrypted":
     "latest@sha256:906f05fd398edca621cc466f0de322c1e827eb7dd2b78f82c7ea46bd0cd69c18",
-  "shepherdjerred/scout-for-lol/beta": "1.0.2",
+  "shepherdjerred/scout-for-lol/beta": "1.0.6",
   "shepherdjerred/scout-for-lol/prod": "1.0.2",
 };
 


### PR DESCRIPTION
This PR updates the scout-for-lol version to 1.0.6