### PR TITLE
chore: update scout-for-lol version to 1.0.61

### DIFF
--- a/cdk8s/src/versions.ts
+++ b/cdk8s/src/versions.ts
@@ -100,7 +100,7 @@ const versions = {
   "openthread/otbr": "latest",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=docker
   "jorenn92/maintainerr": "latest",
-  "shepherdjerred/scout-for-lol/beta": "1.0.60",
+  "shepherdjerred/scout-for-lol/beta": "1.0.61",
   "shepherdjerred/scout-for-lol/prod": "1.0.2",
 };
 


### PR DESCRIPTION
This PR updates the scout-for-lol version to 1.0.61