### PR TITLE
chore: update scout-for-lol version to 1.0.86

### DIFF
--- a/cdk8s/src/versions.ts
+++ b/cdk8s/src/versions.ts
@@ -102,7 +102,7 @@ const versions = {
   "jorenn92/maintainerr": "latest",
   // renovate: datasource=helm registryUrl=https://grafana.github.io/helm-charts versioning=semver
   "loki-stack": "6.24.0",
-  "shepherdjerred/scout-for-lol/beta": "1.0.85",
+  "shepherdjerred/scout-for-lol/beta": "1.0.86",
   "shepherdjerred/scout-for-lol/prod": "1.0.2",
 };
 


### PR DESCRIPTION
This PR updates the scout-for-lol version to 1.0.86