### PR TITLE
chore: update scout-for-lol version to 1.0.112

### DIFF
--- a/cdk8s/src/versions.ts
+++ b/cdk8s/src/versions.ts
@@ -104,7 +104,7 @@ const versions = {
   "loki": "6.25.0",
   // renovate: datasource=helm registryUrl=https://grafana.github.io/helm-charts versioning=semver
   "promtail": "6.16.6",
-  "shepherdjerred/scout-for-lol/beta": "1.0.111",
+  "shepherdjerred/scout-for-lol/beta": "1.0.112",
   "shepherdjerred/scout-for-lol/prod": "1.0.2",
 };
 


### PR DESCRIPTION
This PR updates the scout-for-lol version to 1.0.112