### PR TITLE
chore: update scout-for-lol version to 1.0.165

### DIFF
--- a/cdk8s/src/versions.ts
+++ b/cdk8s/src/versions.ts
@@ -97,7 +97,7 @@ const versions = {
   "loki": "6.28.0",
   // renovate: datasource=helm registryUrl=https://grafana.github.io/helm-charts versioning=semver
   "promtail": "6.16.6",
-  "shepherdjerred/scout-for-lol/beta": "1.0.160",
+  "shepherdjerred/scout-for-lol/beta": "1.0.165",
   "shepherdjerred/scout-for-lol/prod": "1.0.2",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "stashapp/stash":


### PR DESCRIPTION
This PR updates the scout-for-lol version to 1.0.165