### PR TITLE
Build and publish HA image with run number

### DIFF
--- a/src/cdk8s/src/services/home/ha.ts
+++ b/src/cdk8s/src/services/home/ha.ts
@@ -2,6 +2,7 @@ import { Deployment, DeploymentStrategy, EnvValue, Secret } from "cdk8s-plus-31"
 import { Chart } from "cdk8s";
 import { withCommonProps } from "../../utils/common.ts";
 import { OnePasswordItem } from "../../../imports/onepassword.com.ts";
+import versions from "../../versions.ts";
 
 export function createHaDeployment(chart: Chart) {
   const deployment = new Deployment(chart, "ha", {
@@ -24,7 +25,7 @@ export function createHaDeployment(chart: Chart) {
 
   deployment.addContainer(
     withCommonProps({
-      image: `ghcr.io/shepherdjerred/homelab:latest`,
+      image: `ghcr.io/shepherdjerred/homelab:${versions["shepherdjerred/homelab"]}`,
       envVariables: {
         HASS_TOKEN: EnvValue.fromSecretValue({
           secret,

--- a/src/cdk8s/src/versions.ts
+++ b/src/cdk8s/src/versions.ts
@@ -63,6 +63,9 @@ const versions = {
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=docker
   "home-assistant/home-assistant":
     "2025.6.1@sha256:857745bd01589750174e60f2c477a65da1169c4f1c098a58db792baae7f7ada6",
+  // Custom homelab HA image - updated by CI pipeline
+  "shepherdjerred/homelab":
+    "latest",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver
   "linuxserver/syncthing":
     "1.29.7@sha256:2600853512ea2744d88b05fba7524d4bc6d99e14975d408a7f53beee0a2b83e1",


### PR DESCRIPTION
HA image versioning now uses GitHub Actions run numbers for a 1:1 mapping between CI builds and deployed versions.

*   `src/cdk8s/src/versions.ts` was updated to include a new entry for the custom HA image, `"shepherdjerred/homelab": "latest"`. This entry serves as a placeholder to be dynamically updated during CI.
*   In `src/cdk8s/src/services/home/ha.ts`, the hardcoded `latest` tag for the custom HA image was replaced with a reference to `versions["shepherdjerred/homelab"]`, ensuring the deployment consumes the version from the `versions.ts` file.
*   A new Dagger function, `updateHaVersion()`, was added to `.dagger/src/index.ts`. This function uses `sed` to programmatically update the `"shepherdjerred/homelab"` entry in `versions.ts` with the GitHub Actions run number.
*   The Dagger CI pipeline's `ci()` function in `.dagger/src/index.ts` was modified to call `updateHaVersion()` early in the production build flow. This ensures that all subsequent steps, including building and publishing the HA image and Helm chart, utilize the consistent, run-number-based version.

This implementation ensures that the HA image is built, tagged, and published with the GHA run number, aligning its versioning with the existing chart versioning system.