### PR TITLE
Pin docker images in dagger pipeline

### DIFF
--- a/.dagger/src/base.ts
+++ b/.dagger/src/base.ts
@@ -1,4 +1,5 @@
 import { dag, Container, Directory } from "@dagger.io/dagger";
+import versions from "../../src/cdk8s/src/versions";
 
 /**
  * Returns a base Bun container with Python and build tools installed, the source directory mounted, and dependencies installed.
@@ -13,7 +14,7 @@ export function getBaseContainer(
 ): Container {
   return dag
     .container()
-    .from("oven/bun:latest")
+    .from(`oven/bun:${versions["oven/bun"]}`)
     // Cache APT packages
     .withMountedCache("/var/cache/apt", dag.cacheVolume("apt-cache"))
     .withMountedCache("/var/lib/apt", dag.cacheVolume("apt-lib"))
@@ -34,7 +35,7 @@ export function getBaseContainer(
 export function getUbuntuBaseContainer(source: Directory): Container {
   return dag
     .container()
-    .from("ubuntu:noble")
+    .from(`ubuntu:${versions.ubuntu}`)
     .withWorkdir("/workspace")
     .withMountedDirectory("/workspace", source)
     // Cache APT packages
@@ -60,7 +61,7 @@ export function getUbuntuBaseContainer(source: Directory): Container {
 export function getCurlContainer(): Container {
   return dag
     .container()
-    .from("curlimages/curl")
+    .from(`curlimages/curl:${versions["curlimages/curl"]}`)
     // Cache curl configuration and SSL certificates
     .withMountedCache("/root/.curlrc", dag.cacheVolume("curl-config"))
     .withMountedCache("/etc/ssl/certs", dag.cacheVolume("ssl-certs"))
@@ -75,7 +76,7 @@ export function getCurlContainer(): Container {
 export function getKubectlContainer(): Container {
   return dag
     .container()
-    .from("bitnami/kubectl:latest")
+    .from(`bitnami/kubectl:${versions["bitnami/kubectl"]}`)
     // Cache kubectl configuration and temporary files
     .withMountedCache("/root/.kube", dag.cacheVolume("kubectl-config"))
     .withMountedCache("/tmp", dag.cacheVolume("kubectl-tmp"));

--- a/.dagger/src/ha.ts
+++ b/.dagger/src/ha.ts
@@ -1,5 +1,6 @@
 import { Directory, dag, type Secret } from "@dagger.io/dagger";
 import { getBaseContainer } from "./base";
+import versions from "../../src/cdk8s/src/versions";
 
 export async function buildHa(source: Directory): Promise<Directory> {
   return getBaseContainer(source, "/workspace/src/ha")
@@ -43,7 +44,7 @@ export async function buildAndPushHaImage(
 ): Promise<string> {
   let container = dag
     .container()
-    .from("oven/bun:latest")
+    .from(`oven/bun:${versions["oven/bun"]}`)
     // Cache APT packages
     .withMountedCache("/var/cache/apt", dag.cacheVolume("apt-cache"))
     .withMountedCache("/var/lib/apt", dag.cacheVolume("apt-lib"))

--- a/.dagger/src/helm.ts
+++ b/.dagger/src/helm.ts
@@ -1,4 +1,5 @@
 import { dag, Directory, Secret } from "@dagger.io/dagger";
+import versions from "../../src/cdk8s/src/versions";
 
 /**
  * Build the Helm chart, update version/appVersion, and export artifacts.
@@ -13,7 +14,7 @@ export async function build(
 ): Promise<Directory> {
   const container = dag
     .container()
-    .from("alpine/helm:3")
+    .from(`alpine/helm:${versions["alpine/helm"]}`)
     // Cache Helm registry data and repositories
     .withMountedCache("/root/.cache/helm", dag.cacheVolume("helm-cache"))
     .withMountedCache("/root/.config/helm", dag.cacheVolume("helm-config"))
@@ -56,7 +57,7 @@ export async function publish(
   const chartFile = `torvalds-${version}.tgz`;
   const container = dag
     .container()
-    .from("alpine/helm:3")
+    .from(`alpine/helm:${versions["alpine/helm"]}`)
     // Cache Helm registry data and repositories
     .withMountedCache("/root/.cache/helm", dag.cacheVolume("helm-cache"))
     .withMountedCache("/root/.config/helm", dag.cacheVolume("helm-config"))

--- a/src/cdk8s/src/versions.ts
+++ b/src/cdk8s/src/versions.ts
@@ -95,6 +95,18 @@ const versions = {
   "gha-runner-scale-set-runner": "0.12.0",
   // renovate: datasource=helm registryUrl=oci://registry.dagger.io/dagger versioning=semver
   "dagger-helm": "0.18.10",
+
+  // Dagger CI/CD Docker images
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
+  "oven/bun": "1.1.48",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  "ubuntu": "24.04",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  "curlimages/curl": "8.12.1",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  "bitnami/kubectl": "1.32.1",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  "alpine/helm": "3.16.4",
 };
 
 export default versions;


### PR DESCRIPTION
Docker images used by Dagger functions were pinned to versions defined in `src/cdk8s/src/versions.ts`.

*   New entries for `oven/bun`, `ubuntu`, `curlimages/curl`, `bitnami/kubectl`, and `alpine/helm` were added to `src/cdk8s/src/versions.ts`, including Renovate annotations for automatic updates.
*   Dagger functions in `.dagger/src/base.ts`, `.dagger/src/ha.ts`, and `.dagger/src/helm.ts` were updated to import and utilize these pinned versions.
*   The `updateHaVersion` function and related logic were removed from `.dagger/src/index.ts`, and the `shepherdjerred/homelab` entry was removed from `src/cdk8s/src/versions.ts`. This clarifies that `ghcr.io/shepherdjerred/homelab:latest` is an output image built by the pipeline, not an input image to be pinned by `versions.ts`.
*   Consequently, `src/cdk8s/src/services/home/ha.ts` was reverted to use `:latest` for the output `homelab` image.

These changes enhance reproducibility, consistency, and enable centralized version management for Dagger's input Docker images.