### PR TITLE
chore: update scout-for-lol version to 1.0.100

### DIFF
--- a/src/cdk8s/src/versions.ts
+++ b/src/cdk8s/src/versions.ts
@@ -80,7 +80,7 @@ const versions = {
   // renovate: datasource=helm registryUrl=https://openebs.github.io/openebs versioning=semver
   openebs: "4.3.2",
   // not managed by renovate
-  "shepherdjerred/scout-for-lol/beta": "1.0.98",
+  "shepherdjerred/scout-for-lol/beta": "1.0.100",
   // not managed by renovate
   "shepherdjerred/scout-for-lol/prod": "1.0.167",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker


### PR DESCRIPTION
This PR updates the scout-for-lol version to 1.0.100